### PR TITLE
Rep state

### DIFF
--- a/lib/__tests__/regex.test.js
+++ b/lib/__tests__/regex.test.js
@@ -72,6 +72,12 @@ describe('exec', () => {
     expect(exec(exp, 'foo')).toEqual(['foo']);
   });
 
+  it('(.*)*', () => {
+    const exp = parse('(.*)*');
+    expect(exec(exp, '')).toEqual(['', null]);
+    expect(exec(exp, 'f')).toEqual(['f', 'f']);
+  });
+
   it('\\.', () => {
     const exp = parse('\\.');
     expect(exec(exp, '')).toEqual(null);
@@ -112,6 +118,32 @@ describe('exec', () => {
     const exp = parse('(a)|');
     expect(exec(exp, 'a')).toEqual(['a', 'a']);
     expect(exec(exp, 'b')).toEqual(['', null]);
+  });
+
+  it('f{1,2}', () => {
+    const exp = parse('f{1,2}');
+    expect(exec(exp, '')).toEqual(null);
+    expect(exec(exp, 'f')).toEqual(['f']);
+    expect(exec(exp, 'ff')).toEqual(['ff']);
+    expect(exec(exp, 'fff')).toEqual(['ff']);
+  });
+
+  it('(f{1,2})*', () => {
+    const exp = parse('(f{1,2})*');
+    expect(exec(exp, 'f')).toEqual(['f', 'f']);
+    expect(exec(exp, 'ff')).toEqual(['ff', 'ff']);
+    expect(exec(exp, 'fff')).toEqual(['fff', 'f']);
+    expect(exec(exp, 'ffff')).toEqual(['ffff', 'ff']);
+  });
+
+  it('(h{1,2}a)*', () => {
+    const exp = parse('(h{1,2}a)*');
+    expect(exec(exp, 'hahaha')).toEqual(['hahaha', 'ha']);
+  });
+
+  it('()*', () => {
+    const exp = parse('()*');
+    expect(exec(exp, '')).toEqual(['', null]);
   });
 
   it('\\w', () => {

--- a/lib/__tests__/regex.test.js
+++ b/lib/__tests__/regex.test.js
@@ -74,7 +74,7 @@ describe('exec', () => {
 
   it('(.*)*', () => {
     const exp = parse('(.*)*');
-    expect(exec(exp, '')).toEqual(['', null]);
+    expect(exec(exp, '')).toEqual(['', undefined]);
     expect(exec(exp, 'f')).toEqual(['f', 'f']);
   });
 
@@ -117,7 +117,7 @@ describe('exec', () => {
   it('(a)|', () => {
     const exp = parse('(a)|');
     expect(exec(exp, 'a')).toEqual(['a', 'a']);
-    expect(exec(exp, 'b')).toEqual(['', null]);
+    expect(exec(exp, 'b')).toEqual(['', undefined]);
   });
 
   it('f{1,2}', () => {
@@ -143,7 +143,7 @@ describe('exec', () => {
 
   it('()*', () => {
     const exp = parse('()*');
-    expect(exec(exp, '')).toEqual(['', null]);
+    expect(exec(exp, '')).toEqual(['', undefined]);
   });
 
   it('\\w', () => {

--- a/lib/ast.ts
+++ b/lib/ast.ts
@@ -4,42 +4,51 @@ export type Expression = T.Pattern | T.Group | T.CapturingGroup | T.LookaroundAs
 
 export type Visit<R> = (node: T.Node) => R;
 
-export interface Visitors<R> {
-  RegExpLiteral?: (node: T.RegExpLiteral, visit: Visit<R>) => R;
-  Pattern?: (node: T.Pattern, visit: Visit<R>) => R;
-  Alternative?: (node: T.Alternative, visit: Visit<R>) => R;
-  Group?: (node: T.Group, visit: Visit<R>) => R;
-  CapturingGroup?: (node: T.CapturingGroup, visit: Visit<R>) => R;
-  Assertion?: (node: T.Assertion, visit: Visit<R>) => R;
-  Quantifier?: (node: T.Quantifier, visit: Visit<R>) => R;
-  CharacterClass?: (node: T.CharacterClass, visit: Visit<R>) => R;
-  CharacterClassRange?: (node: T.CharacterClassRange, visit: Visit<R>) => R;
-  CharacterSet?: (node: T.CharacterSet, visit: Visit<R>) => R;
-  Character?: (node: T.Character, visit: Visit<R>) => R;
-  Backreference?: (node: T.Backreference, visit: Visit<R>) => R;
-  Flags?: (node: T.Flags, visit: Visit<R>) => R;
+export interface Visitors<R, S> {
+  RegExpLiteral?: (node: T.RegExpLiteral, state: S, visit: Visit<R>) => R;
+  Pattern?: (node: T.Pattern, state: S, visit: Visit<R>) => R;
+  Alternative?: (node: T.Alternative, state: S, visit: Visit<R>) => R;
+  Group?: (node: T.Group, state: S, visit: Visit<R>) => R;
+  CapturingGroup?: (node: T.CapturingGroup, state: S, visit: Visit<R>) => R;
+  Assertion?: (node: T.Assertion, state: S, visit: Visit<R>) => R;
+  Quantifier?: (node: T.Quantifier, state: S, visit: Visit<R>) => R;
+  CharacterClass?: (node: T.CharacterClass, state: S, visit: Visit<R>) => R;
+  CharacterClassRange?: (node: T.CharacterClassRange, state: S, visit: Visit<R>) => R;
+  CharacterSet?: (node: T.CharacterSet, state: S, visit: Visit<R>) => R;
+  Character?: (node: T.Character, state: S, visit: Visit<R>) => R;
+  Backreference?: (node: T.Backreference, state: S, visit: Visit<R>) => R;
+  Flags?: (node: T.Flags, state: S, visit: Visit<R>) => R;
 }
 
 export { RegExpParser as Parser } from 'regexpp';
 
-export class SimpleVisitor<R> {
-  private readonly visitors: Visitors<R>;
+export class SimpleVisitor<R, S> {
+  private readonly visitors: Visitors<R, S>;
 
-  public constructor(visitors: Visitors<R>) {
+  public constructor(visitors: Visitors<R, S>) {
     this.visitors = visitors;
   }
 
-  public visit = (node: T.Node): R => {
-    return this.visitors[node.type]!(node as any, this.visit);
-  };
+  public visit(node: T.Node, state: S): R {
+    return this.visitors[node.type]!(node as any, state, (node) => this.visit(node, state));
+  }
 }
 
-export function visit<R>(node: T.Node, visitors: Visitors<R>): R {
-  return new SimpleVisitor(visitors).visit(node);
+export function visit<R, S>(node: T.Node, state: S, visitors: Visitors<R, S>): R {
+  return new SimpleVisitor(visitors).visit(node, state);
 }
 
-export const literalNames = {
+const literalNames = {
+  any: '.',
   digit: '\\d',
   space: '\\s',
   word: '\\w',
+};
+
+export const getCharSetDesc = (node: T.CharacterSet) => {
+  if (node.kind === 'property') {
+    return `\\p{${node.key}}`;
+  } else {
+    return literalNames[node.kind];
+  }
 };

--- a/lib/captures.ts
+++ b/lib/captures.ts
@@ -11,7 +11,7 @@ function _flattenCapture(capture: Capture, captures: Array<string | null>) {
 }
 
 export function flattenCapture(capture: Capture, capturesLen: number): Array<string | null> {
-  const captures = new Array(capturesLen).fill(null);
+  const captures = new Array(capturesLen).fill(undefined);
   _flattenCapture(capture, captures);
   return captures;
 }

--- a/lib/engine.ts
+++ b/lib/engine.ts
@@ -204,19 +204,22 @@ export class Engine {
     this.captures = [];
   }
 
-  step0(atStart: boolean, atEnd: boolean) {
+  step0(atStart: boolean, atEnd: boolean, idx: number) {
     let seq = this.root === null ? null : this.root.best;
+
+    const context: Record<never, never> = { atStart, atEnd, idx };
 
     while (seq !== null) {
       const { state } = seq;
 
+      // not sure this is still needed...
       if (state.type === 'expr' || state.type === 'success') {
         seq = state.expr !== null ? state.expr.best : seq.next;
       } else {
         const { next, state: matchState } = state;
 
         if (next.width === 0) {
-          seq = seq.replaceWith(next.match(matchState));
+          seq = seq.replaceWith(next.match(matchState, context));
         } else if (atEnd) {
           seq = seq.fail();
         } else {

--- a/lib/generate.ts
+++ b/lib/generate.ts
@@ -9,7 +9,7 @@ function* generate(pattern: Pattern, iterable: Iterable<string>) {
   let value, done;
 
   try {
-    ({ value, done } = engine.step0(true, peekr.done));
+    ({ value, done } = engine.step0(true, peekr.done, peekr.index));
     if (value !== null) yield* value;
 
     while (!done && !peekr.done) {
@@ -17,7 +17,7 @@ function* generate(pattern: Pattern, iterable: Iterable<string>) {
 
       peekr.advance();
 
-      ({ value, done } = engine.step0(false, peekr.done));
+      ({ value, done } = engine.step0(false, peekr.done, peekr.index));
       if (value !== null) yield* value;
     }
   } finally {

--- a/lib/literals.ts
+++ b/lib/literals.ts
@@ -1,4 +1,8 @@
+import { Character, CharacterClass, CharacterClassRange, CharacterSet, Node } from 'regexpp/ast';
+import { Flags } from './types';
+
 export const code = (str: string) => str.charCodeAt(0);
+export const upperValue = (c: number) => String.fromCharCode(c).toUpperCase().charCodeAt(0);
 const inRange = (value: number, lo: number, hi: number) => value >= lo && value <= hi;
 
 const c_ = code('_');
@@ -15,16 +19,18 @@ const cHT = code('\t');
 const cVT = code('\v');
 const cFF = code('\f');
 
+type Tester = (c: number) => boolean;
+
 // These definitions are mostly taken from MDN
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes
 
-const testNewline = (c: number) => {
-  return c === cCR || c === cLF || c === 0x2028 || c === 0x2029;
+const testNotNewline: Tester = (c) => {
+  return c !== cCR && c !== cLF && c !== 0x2028 && c !== 0x2029;
 };
-const testDigit = (c: number) => {
+const testDigit: Tester = (c) => {
   return inRange(c, c0, c9);
 };
-const testSpace = (c: number) => {
+const testSpace: Tester = (c) => {
   return (
     c === cSP ||
     c === cCR ||
@@ -43,15 +49,67 @@ const testSpace = (c: number) => {
     c === 0xfeff
   );
 };
-const testWord = (c: number) => {
+const testWord: Tester = (c) => {
   return inRange(c, cA, cZ) || inRange(c, ca, cz) || inRange(c, c0, c9) || c === c_;
 };
-const testAny = (c: number) => true;
+const testAny: Tester = () => true;
 
-export const testers = {
-  newline: testNewline,
+// Because this is unimplemented
+const testProperty: Tester = () => false;
+
+const testers = {
   digit: testDigit,
   space: testSpace,
+  property: testProperty,
   word: testWord,
   any: testAny,
+};
+
+export const getCharTester = (node: Character, flags: Flags): Tester => {
+  if (flags.ignoreCase) {
+    const value = upperValue(node.value);
+    return (c) => upperValue(c) === value;
+  } else {
+    const { value } = node;
+    return (c) => value === c;
+  }
+};
+
+export const getCharSetTester = (node: CharacterSet, flags: Flags): Tester => {
+  if (node.kind === 'any' && !flags.dotAll) {
+    return testNotNewline;
+  } else {
+    return testers[node.kind];
+  }
+};
+
+export const getCharClassRangeTester = (node: CharacterClassRange, flags: Flags): Tester => {
+  if (flags.ignoreCase) {
+    const upperMin = upperValue(node.min.value);
+    const upperMax = upperValue(node.max.value);
+    return (c) => inRange(upperValue(c), upperMin, upperMax);
+  } else {
+    const min = node.min.value;
+    const max = node.max.value;
+    return (c) => inRange(c, min, max);
+  }
+};
+
+export const getCharClassTester = (node: CharacterClass, flags: Flags): Tester => (c) => {
+  return node.elements.map((node) => getTester(node, flags)).findIndex((tester) => tester(c)) >= 0;
+};
+
+export const getTester = (node: Node, flags: Flags): Tester => {
+  switch (node.type) {
+    case 'CharacterSet':
+      return getCharSetTester(node, flags);
+    case 'CharacterClass':
+      return getCharClassTester(node, flags);
+    case 'CharacterClassRange':
+      return getCharClassRangeTester(node, flags);
+    case 'Character':
+      return getCharTester(node, flags);
+    default:
+      throw new Error(`${node.type} cannot be tested`);
+  }
 };

--- a/lib/rbt.ts
+++ b/lib/rbt.ts
@@ -1,0 +1,12 @@
+// @ts-ignore
+import _createTree from 'functional-red-black-tree';
+
+export type ImmutableTree<K, V> = {
+  get(key: K): V;
+  insert(key: K, value: V): ImmutableTree<K, V>;
+  find(key: K): { update: (value: V) => ImmutableTree<K, V> };
+};
+
+export const createTree: <K, V>(
+  comparator: (a: K, b: K) => number,
+) => ImmutableTree<K, V> = _createTree;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,15 +1,26 @@
 import { ImmutableStackFrame as Stack } from '@iter-tools/imm-stack';
+import { ImmutableTree } from './rbt';
 
 export { Stack };
 
-export type Pattern = {
-  expr: ExpressionResult;
-  source: string;
-  flags: string;
+export type Flags = {
   global: boolean;
   ignoreCase: boolean;
   multiline: boolean;
   dotAll: boolean;
+  unicode: boolean;
+};
+
+export type Pattern = Flags & {
+  expr: ExpressionResult;
+  source: string;
+  flags: string;
+};
+
+export type RepetitionState = {
+  min: number;
+  max: number;
+  context: Record<never, never>;
 };
 
 export type MatchState = {
@@ -18,6 +29,7 @@ export type MatchState = {
     stack: Stack<Capture>;
     list: Stack<Capture>;
   };
+  repetitionStates: ImmutableTree<number, RepetitionState>;
 };
 
 export type ExpressionResult = {
@@ -41,11 +53,19 @@ export type FailureResult = null;
 
 export type Result = ContinuationResult | ExpressionResult | SuccessResult | FailureResult;
 
-export type Matcher = {
-  width: 0 | 1;
+export type Width0Matcher = {
+  width: 0;
   desc: string;
-  match(state: MatchState, chr?: string): Result;
+  match(state: MatchState, context: Record<never, never>): Result;
 };
+
+export type Width1Matcher = {
+  width: 1;
+  desc: string;
+  match(state: MatchState, chr: string): Result;
+};
+
+export type Matcher = Width0Matcher | Width1Matcher;
 
 export type UnboundMatcher = (next: Matcher) => Matcher;
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@iter-tools/imm-stack": "^1.0.0",
+    "functional-red-black-tree": "^1.0.1",
     "iter-tools-es": "^7.0.2",
     "regexpp": "^3.1.0"
   },


### PR DESCRIPTION
Adds character classes and case insensitivity. Fixes looping when empty repetitions are repeated. Eliminates recompilation of pattern that `repeat` had been causing. Better than Google's?

Fixes #6
Fixes #8
